### PR TITLE
Avoid zero-width ring shadows in adaptive frame borders

### DIFF
--- a/.changeset/300-tailwind-adaptive-frame-ring-paint.md
+++ b/.changeset/300-tailwind-adaptive-frame-ring-paint.md
@@ -1,0 +1,5 @@
+---
+"@ariakit/tailwind": patch
+---
+
+Fixed faint rounded-corner shadows in Firefox when adaptive frame bordering selects a border.

--- a/app/src/sandbox/ariakit-tailwind-7470/index.react.tsx
+++ b/app/src/sandbox/ariakit-tailwind-7470/index.react.tsx
@@ -1,0 +1,43 @@
+import "./style.css";
+
+const edges = [
+  ["Default", "ak-frame-bordering"],
+  ["Explicit", "ak-frame-bordering-4"],
+  ["Inherited", "ak-frame-bordering-inherit"],
+  ["Fractional", "ak-frame-bordering-[0.5px]"],
+  ["Zero", "ak-frame-bordering-0"],
+  ["Inset", "ak-frame-bordering-4 ring-inset ring-red-500/50"],
+] as const;
+
+export default function Example() {
+  return (
+    <div className="ak-layer ak-layer-white dark:ak-layer-gray-950 grid gap-4 p-8">
+      {[
+        ["Darkening", "ak-layer-darken-30"],
+        ["Lightening", "ak-layer-lighten-30"],
+      ].map(([label, layer]) => (
+        <section
+          key={label}
+          aria-label={label}
+          className="ak-layer ak-layer-cyan-500 dark:ak-layer-cyan-950 ak-frame ak-frame-2xl/4 ak-frame-bordering-4 flex flex-wrap gap-6"
+        >
+          {edges.map(([edge, className]) => (
+            <button
+              key={edge}
+              type="button"
+              className={`ak-layer ak-frame ak-frame-xl/2 ak-edge-saturate-60 ak-edge-raw shadow-md inset-shadow-sm focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 ${layer} ${className}`}
+            >
+              {label} {edge}
+            </button>
+          ))}
+          <button
+            type="button"
+            className="ak-frame ak-frame-xl/2 ak-frame-bordering-4"
+          >
+            {label} Theme
+          </button>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/app/src/sandbox/ariakit-tailwind-7470/style.css
+++ b/app/src/sandbox/ariakit-tailwind-7470/style.css
@@ -1,0 +1,24 @@
+@import "tailwindcss" source(none);
+@import "@ariakit/tailwind";
+
+@source "./index.react.tsx";
+
+@theme {
+  --default-ring-color: #ff0000;
+  --spacing: 0.25rem;
+  --spacing-px: 1px;
+  --radius: 0.25rem;
+}
+
+@theme inline {
+  --radius-none: 0;
+  --radius-xs: calc(var(--radius) * 0.5);
+  --radius-sm: calc(var(--radius) * 1);
+  --radius-md: calc(var(--radius) * 1.5);
+  --radius-lg: calc(var(--radius) * 2);
+  --radius-xl: calc(var(--radius) * 3);
+  --radius-2xl: calc(var(--radius) * 4);
+  --radius-3xl: calc(var(--radius) * 6);
+  --radius-4xl: calc(var(--radius) * 8);
+  --radius-full: calc(var(--radius) * infinity);
+}

--- a/app/src/sandbox/ariakit-tailwind-7470/test-chrome-firefox.ts
+++ b/app/src/sandbox/ariakit-tailwind-7470/test-chrome-firefox.ts
@@ -1,0 +1,123 @@
+import { expect } from "@playwright/test";
+import { withFramework } from "#app/test-utils/preview.ts";
+
+function paintedShadows(shadow: string) {
+  // Discard transparent layers across RGB/OKLCH and inset serialization.
+  return shadow.replace(
+    /(?:oklch\([^)]* \/ 0\)|rgba\(0, 0, 0, 0\)) 0px 0px 0px 0px(?: inset)?(?:, )?/g,
+    "",
+  );
+}
+
+withFramework(import.meta.dirname, async ({ test }) => {
+  for (const colorScheme of ["light", "dark"] as const) {
+    test.describe(colorScheme, () => {
+      test.use({ colorScheme });
+
+      // https://github.com/ariakit/ariakit/issues/7470
+      test("suppresses zero-width ring paint and preserves frame geometry", async ({
+        q,
+      }) => {
+        let borders = 0;
+        let rings = 0;
+        for (const direction of ["Darkening", "Lightening"]) {
+          for (const [variant, width] of [
+            ["Default", 1],
+            ["Explicit", 4],
+            ["Inherited", 4],
+            ["Fractional", 0.5],
+            ["Zero", 0],
+            ["Inset", 4],
+            ["Theme", 4],
+          ] as const) {
+            const button = q.button(`${direction} ${variant}`);
+            const style = await button.evaluate((element) => {
+              const style = getComputedStyle(element);
+              return {
+                border: Number.parseFloat(style.borderTopWidth),
+                ring: Number.parseFloat(
+                  style.getPropertyValue("--ak-frame-ring"),
+                ),
+                shadow: style.boxShadow,
+                radius: style.borderTopLeftRadius,
+                padding: style.paddingTop,
+              };
+            });
+            expect(style.radius).toBe("12px");
+            expect(style.padding).toBe("8px");
+            if (style.ring > 0) {
+              rings += 1;
+              expect(style.ring).toBe(width);
+              expect(style.border).toBe(0);
+              const originalShadow = await button.evaluate((element) => {
+                const style = getComputedStyle(element);
+                const width = style.getPropertyValue("--ak-frame-ring");
+                const color =
+                  style.getPropertyValue("--tw-ring-color") ||
+                  style.getPropertyValue("--default-ring-color");
+                const inset = style.getPropertyValue("--tw-ring-inset");
+                // Compare colors in one space without changing their alpha.
+                element.style.setProperty(
+                  "--tw-ring-shadow",
+                  `${inset} 0 0 0 ${width} oklch(from ${color} l c h)`,
+                );
+                const shadow = getComputedStyle(element).boxShadow;
+                element.style.removeProperty("--tw-ring-shadow");
+                return shadow;
+              });
+              expect(style.shadow).toBe(originalShadow);
+              continue;
+            }
+            borders += 1;
+            // Browsers quantize fractional border widths to physical pixels.
+            expect(style.border).toBe(width === 0.5 ? 1 : width);
+            const withoutRing = await button.evaluate((element) => {
+              element.style.setProperty("--tw-ring-shadow", "0 0 #0000");
+              return getComputedStyle(element).boxShadow;
+            });
+            // The diagnostic removes only the ring term, preserving other
+            // shadows.
+            expect(paintedShadows(style.shadow)).toBe(
+              paintedShadows(withoutRing),
+            );
+            await button.evaluate((element) =>
+              element.style.removeProperty("--tw-ring-shadow"),
+            );
+          }
+        }
+        expect(borders).toBeGreaterThan(0);
+        expect(rings).toBeGreaterThan(0);
+      });
+
+      // https://github.com/ariakit/ariakit/issues/7470
+      test("preserves focus rings and composed shadows", async ({ q }) => {
+        const button = q.button("Darkening Explicit");
+        const shadow = await button.evaluate((element) => {
+          const style = getComputedStyle(element);
+          return [
+            style.getPropertyValue("--tw-shadow"),
+            style.getPropertyValue("--tw-inset-shadow"),
+          ];
+        });
+        await button.focus();
+        await expect(button).toBeFocused();
+        const focused = await button.evaluate((element) => {
+          const style = getComputedStyle(element);
+          return {
+            ring: style.boxShadow,
+            offset: style.getPropertyValue("--tw-ring-offset-width"),
+            shadow: [
+              style.getPropertyValue("--tw-shadow"),
+              style.getPropertyValue("--tw-inset-shadow"),
+            ],
+          };
+        });
+        expect(focused.ring).toContain(
+          "oklch(0.546 0.245 262.881) 0px 0px 0px 4px",
+        );
+        expect(focused.offset).toBe("2px");
+        expect(focused.shadow).toEqual(shadow);
+      });
+    });
+  }
+});

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/dark
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/dark
@@ -110,9 +110,9 @@
         }
       },
       "bordering inherit": {
-        "class": "bg-[oklch(0.1634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[15px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
+        "class": "bg-[oklch(0.1634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[15px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
         "children": {
-          "20": "bg-[oklch(0.3634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[7px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
+          "20": "bg-[oklch(0.3634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[7px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
           "20 (2)": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[7px] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_4px]",
           "skip": {
             "class": "bg-[oklch(0.3634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[7px] p-[4px]",
@@ -123,7 +123,7 @@
           "zero": {
             "class": "bg-[oklch(0.1634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[7px] p-[4px]",
             "children": {
-              "host": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[3px] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]"
+              "host": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[3px] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "host": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[3px] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_4px]"
@@ -251,32 +251,32 @@
             "class": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.1)] border-b-[oklch(1_0.0091_264.28_/_0.1)] border-l-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.526_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.426_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.426_0.368_264.28)] p-[4px] shadow-[oklch(0.426_0.368_264.28)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.326_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.226_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.126_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.026_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.526_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.426_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.426_0.368_264.28)] p-[4px] shadow-[oklch(0.426_0.368_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.326_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.226_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.126_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.026_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.1634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.1634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.2634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.3634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.7634_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.8634_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.9634_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.2634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.3634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.7634_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.8634_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.9634_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -446,32 +446,32 @@
             "class": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.1)] border-b-[oklch(1_0.0091_264.28_/_0.1)] border-l-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.526_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.426_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.426_0.368_264.28)] p-[4px] shadow-[oklch(0.426_0.368_264.28)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.326_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.226_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.126_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.026_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.526_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.426_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.426_0.368_264.28)] p-[4px] shadow-[oklch(0.426_0.368_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.326_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.226_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.126_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.026_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.2634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.2634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.3634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.4634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.7634_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.8634_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.9634_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.3634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.4634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.7634_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.8634_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.9634_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -641,32 +641,32 @@
             "class": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.1)] border-b-[oklch(1_0.0091_264.28_/_0.1)] border-l-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.526_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.426_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.426_0.368_264.28)] p-[4px] shadow-[oklch(0.426_0.368_264.28)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.326_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.226_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.126_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.026_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.526_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.426_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.426_0.368_264.28)] p-[4px] shadow-[oklch(0.426_0.368_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.326_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.226_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.126_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.026_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.5_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.5_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -836,32 +836,32 @@
             "class": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.1)] border-b-[oklch(1_0.0091_264.28_/_0.1)] border-l-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.526_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.426_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.426_0.368_264.28)] p-[4px] shadow-[oklch(0.426_0.368_264.28)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.326_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.226_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.126_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.026_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.526_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.426_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.426_0.368_264.28)] p-[4px] shadow-[oklch(0.426_0.368_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.326_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.226_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.126_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.026_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.5_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.5_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -1031,32 +1031,32 @@
             "class": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.1)] border-b-[oklch(1_0.0091_264.28_/_0.1)] border-l-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.526_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.426_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.426_0.368_264.28)] p-[4px] shadow-[oklch(0.426_0.368_264.28)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.326_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.226_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.126_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.026_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.526_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.426_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.426_0.368_264.28)] p-[4px] shadow-[oklch(0.426_0.368_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.326_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.226_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.126_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.026_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.5_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.5_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -1226,32 +1226,32 @@
             "class": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.1)] border-b-[oklch(1_0.0091_264.28_/_0.1)] border-l-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.526_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.426_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.426_0.368_264.28)] p-[4px] shadow-[oklch(0.426_0.368_264.28)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.326_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.226_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.126_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.026_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.526_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.426_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.426_0.368_264.28)] p-[4px] shadow-[oklch(0.426_0.368_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.326_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.226_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.126_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.026_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.5_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.5_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -1421,32 +1421,32 @@
             "class": "bg-[oklch(0.7634_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0091_264.28_/_0.1)] border-b-[oklch(0_0.0091_264.28_/_0.1)] border-l-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.7634_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4634_0.368_264.28)] p-[4px] shadow-[oklch(0.4634_0.368_264.28)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.3634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.1634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.0634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4634_0.368_264.28)] p-[4px] shadow-[oklch(0.4634_0.368_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.0634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.5_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.5_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -1616,32 +1616,32 @@
             "class": "bg-[oklch(0.8634_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0091_264.28_/_0.1)] border-b-[oklch(0_0.0091_264.28_/_0.1)] border-l-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.8634_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.7634_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.548_0.368_264.28)] p-[4px] shadow-[oklch(0.548_0.368_264.28)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.4634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.3634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.2634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.1634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.0634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.7634_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.548_0.368_264.28)] p-[4px] shadow-[oklch(0.548_0.368_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.4634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.3634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.2634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.1634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.0634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.5_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.5_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -1811,32 +1811,32 @@
             "class": "bg-[oklch(0.9634_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0091_264.28_/_0.1)] border-b-[oklch(0_0.0091_264.28_/_0.1)] border-l-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.9634_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.8634_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.7634_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.726_0.368_264.28)] p-[4px] shadow-[oklch(0.726_0.368_264.28)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.4634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.3634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.2634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.1634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0.0634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.8634_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.7634_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.726_0.368_264.28)] p-[4px] shadow-[oklch(0.726_0.368_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.4634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.3634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.2634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.1634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.0634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.5_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.5_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -2006,32 +2006,32 @@
             "class": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0091_264.28_/_0.1)] border-b-[oklch(0_0.0091_264.28_/_0.1)] border-l-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.726_0.368_264.28)] p-[4px] shadow-[oklch(0.726_0.368_264.28)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.5_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0.1_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.726_0.368_264.28)] p-[4px] shadow-[oklch(0.726_0.368_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.5_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.1_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.5_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.5_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -2201,32 +2201,32 @@
             "class": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0091_264.28_/_0.1)] border-b-[oklch(0_0.0091_264.28_/_0.1)] border-l-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.726_0.368_264.28)] p-[4px] shadow-[oklch(0.726_0.368_264.28)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.5_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0.1_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.726_0.368_264.28)] p-[4px] shadow-[oklch(0.726_0.368_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.5_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.1_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.5_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.5_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -2401,32 +2401,32 @@
             "class": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.1)] border-b-[oklch(1_0.0091_264.28_/_0.1)] border-l-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.526_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.426_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.426_0.368_264.28)] p-[4px] shadow-[oklch(0.426_0.368_264.28)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.326_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.226_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.126_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.026_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.526_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.426_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.426_0.368_264.28)] p-[4px] shadow-[oklch(0.426_0.368_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.326_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.226_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.126_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.026_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.1634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.1634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.2634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.3634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.7634_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.8634_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.9634_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.2634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.3634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.7634_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.8634_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.9634_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -2596,32 +2596,32 @@
             "class": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.1)] border-b-[oklch(1_0.0091_264.28_/_0.1)] border-l-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.526_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.426_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.426_0.368_264.28)] p-[4px] shadow-[oklch(0.426_0.368_264.28)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.326_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.226_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.126_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.026_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.526_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.426_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.426_0.368_264.28)] p-[4px] shadow-[oklch(0.426_0.368_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.326_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.226_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.126_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.026_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.2634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.2634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.3634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.4634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.7634_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.8634_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.9634_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.3634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.4634_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.7634_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.8634_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.9634_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -2791,32 +2791,32 @@
             "class": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.1)] border-b-[oklch(1_0.0091_264.28_/_0.1)] border-l-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.526_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.426_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.426_0.368_264.28)] p-[4px] shadow-[oklch(0.426_0.368_264.28)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.326_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.226_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.126_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.026_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.526_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.426_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.426_0.368_264.28)] p-[4px] shadow-[oklch(0.426_0.368_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.326_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.226_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.126_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.026_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.5_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.5_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -2986,32 +2986,32 @@
             "class": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.1)] border-b-[oklch(1_0.0091_264.28_/_0.1)] border-l-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.526_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.426_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.426_0.368_264.28)] p-[4px] shadow-[oklch(0.426_0.368_264.28)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.326_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.226_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.126_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.026_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.526_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.426_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.426_0.368_264.28)] p-[4px] shadow-[oklch(0.426_0.368_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.326_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.226_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.126_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.026_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.5_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.5_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -3181,32 +3181,32 @@
             "class": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.1)] border-b-[oklch(1_0.0091_264.28_/_0.1)] border-l-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.526_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.426_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.426_0.368_264.28)] p-[4px] shadow-[oklch(0.426_0.368_264.28)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.326_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.226_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.126_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.026_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.526_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.426_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.426_0.368_264.28)] p-[4px] shadow-[oklch(0.426_0.368_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.326_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.226_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.126_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.026_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.5_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.5_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -3376,32 +3376,32 @@
             "class": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0091_264.28_/_0.1)] border-b-[oklch(0_0.0091_264.28_/_0.1)] border-l-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.726_0.368_264.28)] p-[4px] shadow-[oklch(0.726_0.368_264.28)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.5_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0.1_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.726_0.368_264.28)] p-[4px] shadow-[oklch(0.726_0.368_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.5_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.1_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.5_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.5_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.548_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.726_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -3576,32 +3576,32 @@
             "class": "bg-[oklch(0.725_0_0)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0_0_/_0.1)] border-b-[oklch(1_0_0_/_0.1)] border-l-[oklch(1_0_0_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.725_0_0)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0_0_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.55_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.525_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0_0_/_0.5)] p-[4px] shadow-[oklch(1_0_0_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.425_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.425_0.368_0)] p-[4px] shadow-[oklch(0.425_0.368_0)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.325_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.225_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.125_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.025_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.55_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.525_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0_0_/_0.5)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.425_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.425_0.368_0)] p-[4px] shadow-[oklch(0.425_0.368_0_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.325_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.225_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.125_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.025_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0_0_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.23_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.33_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.43_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.53_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.55_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.73_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.83_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.93_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0_0_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.23_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.33_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.43_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.53_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.55_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.73_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.83_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.93_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -3771,32 +3771,32 @@
             "class": "bg-[oklch(0.725_0_0)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0_0_/_0.1)] border-b-[oklch(1_0_0_/_0.1)] border-l-[oklch(1_0_0_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.725_0_0)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0_0_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.55_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.525_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0_0_/_0.5)] p-[4px] shadow-[oklch(1_0_0_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.425_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.425_0.368_0)] p-[4px] shadow-[oklch(0.425_0.368_0)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.325_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.225_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.125_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.025_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.55_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.525_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0_0_/_0.5)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.425_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.425_0.368_0)] p-[4px] shadow-[oklch(0.425_0.368_0_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.325_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.225_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.125_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.025_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.05_0_0)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.05_0_0)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0_0_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.23_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.33_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.43_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.53_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.55_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.73_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.83_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.93_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0_0_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.23_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.33_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.43_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.53_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.55_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.73_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.83_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.93_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -3966,32 +3966,32 @@
             "class": "bg-[oklch(0.7272_0.02_260)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.02_260_/_0.1)] border-b-[oklch(1_0.02_260_/_0.1)] border-l-[oklch(1_0.02_260_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.7272_0.02_260)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.02_260_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.5455_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.1)] p-[4px] shadow-[oklch(0_0.02_260_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.5272_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.02_260_/_0.5)] p-[4px] shadow-[oklch(1_0.02_260_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4272_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4272_0.368_260)] p-[4px] shadow-[oklch(0.4272_0.368_260)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.3272_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.1)] p-[4px] shadow-[oklch(0_0.02_260_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2272_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.1)] p-[4px] shadow-[oklch(0_0.02_260_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.1272_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.1)] p-[4px] shadow-[oklch(0_0.02_260_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.0272_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.1)] p-[4px] shadow-[oklch(0_0.02_260_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.1)] p-[4px] shadow-[oklch(0_0.02_260_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.1)] p-[4px] shadow-[oklch(0_0.02_260_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.1)] p-[4px] shadow-[oklch(0_0.02_260_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.5455_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.1)] p-[4px] shadow-[oklch(0_0.02_260_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.5272_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.02_260_/_0.5)] p-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4272_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4272_0.368_260)] p-[4px] shadow-[oklch(0.4272_0.368_260_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3272_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.1)] p-[4px] shadow-[oklch(0_0.02_260_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2272_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.1)] p-[4px] shadow-[oklch(0_0.02_260_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1272_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.1)] p-[4px] shadow-[oklch(0_0.02_260_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.0272_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.1)] p-[4px] shadow-[oklch(0_0.02_260_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.1)] p-[4px] shadow-[oklch(0_0.02_260_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.1)] p-[4px] shadow-[oklch(0_0.02_260_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.1)] p-[4px] shadow-[oklch(0_0.02_260_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.08_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.08_0.02_260)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.02_260_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.23_0.02_260)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.1)] p-[4px] shadow-[oklch(1_0.02_260_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.33_0.02_260)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.1)] p-[4px] shadow-[oklch(1_0.02_260_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.43_0.02_260)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.1)] p-[4px] shadow-[oklch(1_0.02_260_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.53_0.02_260)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.1)] p-[4px] shadow-[oklch(1_0.02_260_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.5455_0.02_260)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.1)] p-[4px] shadow-[oklch(1_0.02_260_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.73_0.02_260)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.1)] p-[4px] shadow-[oklch(1_0.02_260_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.83_0.02_260)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.1)] p-[4px] shadow-[oklch(1_0.02_260_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.93_0.02_260)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.1)] p-[4px] shadow-[oklch(1_0.02_260_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.1)] p-[4px] shadow-[oklch(1_0.02_260_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.02_260_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.02_260_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.23_0.02_260)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.1)] p-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.33_0.02_260)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.1)] p-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.43_0.02_260)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.1)] p-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.53_0.02_260)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.1)] p-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.5455_0.02_260)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.1)] p-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.73_0.02_260)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.1)] p-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.83_0.02_260)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.1)] p-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.93_0.02_260)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.1)] p-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.1)] p-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.02_260_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -4166,32 +4166,32 @@
             "class": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.245_262.881_/_0.1)] border-b-[oklch(1_0.245_262.881_/_0.1)] border-l-[oklch(1_0.245_262.881_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.5)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4525_0.368_262.881)] p-[4px] shadow-[oklch(0.4525_0.368_262.881)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.3525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.1525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.0525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.5)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4525_0.368_262.881)] p-[4px] shadow-[oklch(0.4525_0.368_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.0525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.3_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.3_0.245_262.881)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.245_262.881_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.4_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.4_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -4361,32 +4361,32 @@
             "class": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.245_262.881_/_0.1)] border-b-[oklch(1_0.245_262.881_/_0.1)] border-l-[oklch(1_0.245_262.881_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.5)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4525_0.368_262.881)] p-[4px] shadow-[oklch(0.4525_0.368_262.881)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.3525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.1525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.0525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.5)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4525_0.368_262.881)] p-[4px] shadow-[oklch(0.4525_0.368_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.0525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.3_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.3_0.245_262.881)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.245_262.881_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.4_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.4_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -4556,32 +4556,32 @@
             "class": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.245_262.881_/_0.1)] border-b-[oklch(1_0.245_262.881_/_0.1)] border-l-[oklch(1_0.245_262.881_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.5)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4525_0.368_262.881)] p-[4px] shadow-[oklch(0.4525_0.368_262.881)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.3525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.1525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.0525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.5)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4525_0.368_262.881)] p-[4px] shadow-[oklch(0.4525_0.368_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.0525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.245_262.881_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.3951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.7951_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.8951_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.9951_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.3951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.7951_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.8951_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.9951_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -4751,32 +4751,32 @@
             "class": "bg-[oklch(0.7951_0.245_262.881)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.245_262.881_/_0.1)] border-b-[oklch(0_0.245_262.881_/_0.1)] border-l-[oklch(0_0.245_262.881_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.7951_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.5)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4951_0.368_262.881)] p-[4px] shadow-[oklch(0.4951_0.368_262.881)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.3951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.1951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.0951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.5)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4951_0.368_262.881)] p-[4px] shadow-[oklch(0.4951_0.368_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.0951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.3_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.3_0.245_262.881)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.245_262.881_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.4_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.4_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -4946,32 +4946,32 @@
             "class": "bg-[oklch(0.8951_0.245_262.881)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.245_262.881_/_0.1)] border-b-[oklch(0_0.245_262.881_/_0.1)] border-l-[oklch(0_0.245_262.881_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.8951_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.7951_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.5)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4951_0.368_262.881)] p-[4px] shadow-[oklch(0.4951_0.368_262.881)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.3951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.1951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.0951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.7951_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.5)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4951_0.368_262.881)] p-[4px] shadow-[oklch(0.4951_0.368_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.3951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.1951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.0951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.3_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.3_0.245_262.881)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.245_262.881_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.4_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.4_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -5141,32 +5141,32 @@
             "class": "bg-[oklch(0.9951_0.245_262.881)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.245_262.881_/_0.1)] border-b-[oklch(0_0.245_262.881_/_0.1)] border-l-[oklch(0_0.245_262.881_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.9951_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.8951_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.7951_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.5)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.7525_0.368_262.881)] p-[4px] shadow-[oklch(0.7525_0.368_262.881)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.3951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.1951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0.0951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.8951_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.7951_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.5)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.7525_0.368_262.881)] p-[4px] shadow-[oklch(0.7525_0.368_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.3951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.1951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.0951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.3_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.3_0.245_262.881)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.245_262.881_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.4_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.4_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/dark-high-contrast
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/dark-high-contrast
@@ -89,7 +89,7 @@
             }
           },
           "inherit skip": {
-            "class": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.3334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.3334)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.3334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
             "children": {
               "host": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[5px] border-[1px] border-[oklch(1_0.245_27.325_/_0.7334)] p-[4px]"
             }
@@ -110,9 +110,9 @@
         }
       },
       "bordering inherit": {
-        "class": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[15px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
+        "class": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[15px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
         "children": {
-          "20": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[7px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
+          "20": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[7px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
           "20 (2)": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[7px] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_4px]",
           "skip": {
             "class": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[7px] p-[4px]",
@@ -123,7 +123,7 @@
           "zero": {
             "class": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[7px] p-[4px]",
             "children": {
-              "host": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[3px] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]"
+              "host": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[3px] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "host": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[3px] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_4px]"
@@ -251,32 +251,32 @@
             "class": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.4334)] border-b-[oklch(1_0.0091_264.28_/_0.4334)] border-l-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.8334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.8334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_264.28)] p-[4px] shadow-[oklch(0.6666_0.368_264.28)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.8334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_264.28)] p-[4px] shadow-[oklch(0.6666_0.368_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5334)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.7334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -446,32 +446,32 @@
             "class": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.4334)] border-b-[oklch(1_0.0091_264.28_/_0.4334)] border-l-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.8334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.8334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_264.28)] p-[4px] shadow-[oklch(0.6666_0.368_264.28)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.8334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_264.28)] p-[4px] shadow-[oklch(0.6666_0.368_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5334)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.7334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -641,32 +641,32 @@
             "class": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.4334)] border-b-[oklch(1_0.0091_264.28_/_0.4334)] border-l-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.8334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.8334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_264.28)] p-[4px] shadow-[oklch(0.6666_0.368_264.28)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.8334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_264.28)] p-[4px] shadow-[oklch(0.6666_0.368_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5334)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.7334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -836,32 +836,32 @@
             "class": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.4334)] border-b-[oklch(1_0.0091_264.28_/_0.4334)] border-l-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.8334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.8334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_264.28)] p-[4px] shadow-[oklch(0.6666_0.368_264.28)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.8334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_264.28)] p-[4px] shadow-[oklch(0.6666_0.368_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5334)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.7334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -1031,32 +1031,32 @@
             "class": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.4334)] border-b-[oklch(1_0.0091_264.28_/_0.4334)] border-l-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.8334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.8334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_264.28)] p-[4px] shadow-[oklch(0.6666_0.368_264.28)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.8334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_264.28)] p-[4px] shadow-[oklch(0.6666_0.368_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5334)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.7334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -1226,32 +1226,32 @@
             "class": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.4334)] border-b-[oklch(1_0.0091_264.28_/_0.4334)] border-l-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.8334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.8334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_264.28)] p-[4px] shadow-[oklch(0.6666_0.368_264.28)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.8334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_264.28)] p-[4px] shadow-[oklch(0.6666_0.368_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5334)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.7334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -1421,32 +1421,32 @@
             "class": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.4334)] border-b-[oklch(1_0.0091_264.28_/_0.4334)] border-l-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.8334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.8334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_264.28)] p-[4px] shadow-[oklch(0.6666_0.368_264.28)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.8334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_264.28)] p-[4px] shadow-[oklch(0.6666_0.368_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5334)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.7334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -1616,32 +1616,32 @@
             "class": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.4334)] border-b-[oklch(1_0.0091_264.28_/_0.4334)] border-l-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.8334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.8334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_264.28)] p-[4px] shadow-[oklch(0.6666_0.368_264.28)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.8334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_264.28)] p-[4px] shadow-[oklch(0.6666_0.368_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5334)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.7334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -1811,32 +1811,32 @@
             "class": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0091_264.28_/_0.4334)] border-b-[oklch(0_0.0091_264.28_/_0.4334)] border-l-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.8334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.8334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_264.28)] p-[4px] shadow-[oklch(0.6666_0.368_264.28)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.8334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_264.28)] p-[4px] shadow-[oklch(0.6666_0.368_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.5334)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.7334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -2006,32 +2006,32 @@
             "class": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0091_264.28_/_0.4334)] border-b-[oklch(0_0.0091_264.28_/_0.4334)] border-l-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.8334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.8334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_264.28)] p-[4px] shadow-[oklch(0.6666_0.368_264.28)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.8334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_264.28)] p-[4px] shadow-[oklch(0.6666_0.368_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.5334)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.7334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -2201,32 +2201,32 @@
             "class": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0091_264.28_/_0.4334)] border-b-[oklch(0_0.0091_264.28_/_0.4334)] border-l-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.8334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.8334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_264.28)] p-[4px] shadow-[oklch(0.6666_0.368_264.28)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.8334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_264.28)] p-[4px] shadow-[oklch(0.6666_0.368_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0666_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.5334)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.7334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1966_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -2401,32 +2401,32 @@
             "class": "bg-[oklch(0.7834_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.1834)] border-b-[oklch(1_0.0091_264.28_/_0.1834)] border-l-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.8667_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.7698_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.5834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.3167_0.368_264.28)] p-[4px] shadow-[oklch(0.3167_0.368_264.28)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.1_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.7698_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.3167_0.368_264.28)] p-[4px] shadow-[oklch(0.3167_0.368_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2834)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.4834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.1467_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.4467_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.8134_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.9134_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.1467_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.4467_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.8134_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.9134_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -2596,32 +2596,32 @@
             "class": "bg-[oklch(0.7834_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.1834)] border-b-[oklch(1_0.0091_264.28_/_0.1834)] border-l-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.8667_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.7698_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.5834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.3167_0.368_264.28)] p-[4px] shadow-[oklch(0.3167_0.368_264.28)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.1_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.7698_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.3167_0.368_264.28)] p-[4px] shadow-[oklch(0.3167_0.368_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.0633_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2834)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.4834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.1467_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.4467_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.8134_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.9134_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.1467_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.2467_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.3467_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.4467_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.8134_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.9134_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -2791,32 +2791,32 @@
             "class": "bg-[oklch(0.7834_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.1834)] border-b-[oklch(1_0.0091_264.28_/_0.1834)] border-l-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.8667_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.7698_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.5834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.3167_0.368_264.28)] p-[4px] shadow-[oklch(0.3167_0.368_264.28)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.1_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.7698_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.3167_0.368_264.28)] p-[4px] shadow-[oklch(0.3167_0.368_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.1633_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2834)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.0799_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.4834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.18_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.2799_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.38_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.7698_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.8467_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.9467_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.18_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.2799_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.38_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.7698_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.8467_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.9467_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -2986,32 +2986,32 @@
             "class": "bg-[oklch(0.7834_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.1834)] border-b-[oklch(1_0.0091_264.28_/_0.1834)] border-l-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.8667_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.7698_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.5834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.3167_0.368_264.28)] p-[4px] shadow-[oklch(0.3167_0.368_264.28)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.1_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.7698_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.3167_0.368_264.28)] p-[4px] shadow-[oklch(0.3167_0.368_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.2167_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2834)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.1333_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.4834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.2333_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.3333_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4333_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.2333_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.3333_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4333_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -3181,32 +3181,32 @@
             "class": "bg-[oklch(0.7834_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0091_264.28_/_0.1834)] border-b-[oklch(1_0.0091_264.28_/_0.1834)] border-l-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.8667_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.7698_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.5834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.3167_0.368_264.28)] p-[4px] shadow-[oklch(0.3167_0.368_264.28)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.1_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.7698_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.3167_0.368_264.28)] p-[4px] shadow-[oklch(0.3167_0.368_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.2167_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2834)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.1333_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.4834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.2333_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.3333_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4333_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.2333_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.3333_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4333_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -3376,32 +3376,32 @@
             "class": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0091_264.28_/_0.1834)] border-b-[oklch(0_0.0091_264.28_/_0.1834)] border-l-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.9834_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.8834_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.5834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.7834_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.7_0.368_264.28)] p-[4px] shadow-[oklch(0.7_0.368_264.28)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.4167_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.3167_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.2167_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.1167_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0.0167_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.9834_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.8834_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0091_264.28_/_0.5834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.7834_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.7_0.368_264.28)] p-[4px] shadow-[oklch(0.7_0.368_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.4167_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.3167_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.2167_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.1167_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.0167_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(0_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.2167_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.2834)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.1333_0.0091_264.28)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0091_264.28_/_0.4834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.2333_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.3333_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4333_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0.1834)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.2333_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.3333_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4333_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.4605_0.0091_264.28)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0091_264.28)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0091_264.28_/_0.1834)] p-[4px] m-[4px] shadow-[oklch(1_0.0091_264.28_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -3576,32 +3576,32 @@
             "class": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0_0_/_0.4334)] border-b-[oklch(1_0_0_/_0.4334)] border-l-[oklch(1_0_0_/_0.4334)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0_0_/_0.4334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0_0_/_0.8334)] p-[4px] shadow-[oklch(1_0_0_/_0.8334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_0)] p-[4px] shadow-[oklch(0.6666_0.368_0)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0666_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0_0_/_0.8334)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_0)] p-[4px] shadow-[oklch(0.6666_0.368_0_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1666_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0666_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5334)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0_0_/_0.7334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1966_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0_0_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0966_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1966_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -3771,32 +3771,32 @@
             "class": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0_0_/_0.4334)] border-b-[oklch(1_0_0_/_0.4334)] border-l-[oklch(1_0_0_/_0.4334)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0_0_/_0.4334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0_0_/_0.8334)] p-[4px] shadow-[oklch(1_0_0_/_0.8334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_0)] p-[4px] shadow-[oklch(0.6666_0.368_0)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0666_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0_0_/_0.8334)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_0)] p-[4px] shadow-[oklch(0.6666_0.368_0_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1666_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0666_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5334)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0_0_/_0.7334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1966_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0_0_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0966_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1966_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -3966,32 +3966,32 @@
             "class": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.02_260_/_0.4334)] border-b-[oklch(1_0.02_260_/_0.4334)] border-l-[oklch(1_0.02_260_/_0.4334)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.02_260_/_0.4334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(0_0.02_260_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.02_260_/_0.8334)] p-[4px] shadow-[oklch(1_0.02_260_/_0.8334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_260)] p-[4px] shadow-[oklch(0.6666_0.368_260)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(0_0.02_260_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(0_0.02_260_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0666_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(0_0.02_260_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(0_0.02_260_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(0_0.02_260_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(0_0.02_260_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(0_0.02_260_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(0_0.02_260_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.02_260_/_0.8334)] p-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_260)] p-[4px] shadow-[oklch(0.6666_0.368_260_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(0_0.02_260_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1666_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(0_0.02_260_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0666_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(0_0.02_260_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(0_0.02_260_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(0_0.02_260_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(0_0.02_260_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(0_0.02_260_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5334)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.02_260)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.02_260_/_0.7334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0_0.02_260)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(1_0.02_260_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.02_260)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(1_0.02_260_/_0.4334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0.02_260)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(1_0.02_260_/_0.4334)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1966_0.02_260)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(1_0.02_260_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.02_260)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(1_0.02_260_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(1_0.02_260_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(1_0.02_260_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(1_0.02_260_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(1_0.02_260_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.02_260_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.02_260_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0_0.02_260)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0_0.02_260)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0966_0.02_260)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1966_0.02_260)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.02_260)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.02_260_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -4166,32 +4166,32 @@
             "class": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.245_262.881_/_0.4334)] border-b-[oklch(1_0.245_262.881_/_0.4334)] border-l-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.8334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.8334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_262.881)] p-[4px] shadow-[oklch(0.6666_0.368_262.881)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.8334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_262.881)] p-[4px] shadow-[oklch(0.6666_0.368_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5334)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.245_262.881_/_0.7334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -4361,32 +4361,32 @@
             "class": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.245_262.881_/_0.4334)] border-b-[oklch(1_0.245_262.881_/_0.4334)] border-l-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.8334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.8334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_262.881)] p-[4px] shadow-[oklch(0.6666_0.368_262.881)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.8334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_262.881)] p-[4px] shadow-[oklch(0.6666_0.368_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5334)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.245_262.881_/_0.7334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -4556,32 +4556,32 @@
             "class": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.245_262.881_/_0.4334)] border-b-[oklch(1_0.245_262.881_/_0.4334)] border-l-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.8334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.8334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_262.881)] p-[4px] shadow-[oklch(0.6666_0.368_262.881)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.8334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_262.881)] p-[4px] shadow-[oklch(0.6666_0.368_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5334)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.245_262.881_/_0.7334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -4751,32 +4751,32 @@
             "class": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.245_262.881_/_0.4334)] border-b-[oklch(1_0.245_262.881_/_0.4334)] border-l-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.8334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.8334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_262.881)] p-[4px] shadow-[oklch(0.6666_0.368_262.881)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.8334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_262.881)] p-[4px] shadow-[oklch(0.6666_0.368_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5334)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.245_262.881_/_0.7334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -4946,32 +4946,32 @@
             "class": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.245_262.881_/_0.4334)] border-b-[oklch(1_0.245_262.881_/_0.4334)] border-l-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.8334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.8334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_262.881)] p-[4px] shadow-[oklch(0.6666_0.368_262.881)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.8334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_262.881)] p-[4px] shadow-[oklch(0.6666_0.368_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5334)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.245_262.881_/_0.7334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -5141,32 +5141,32 @@
             "class": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.245_262.881_/_0.4334)] border-b-[oklch(1_0.245_262.881_/_0.4334)] border-l-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.8334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.8334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_262.881)] p-[4px] shadow-[oklch(0.6666_0.368_262.881)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.8334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_262.881)] p-[4px] shadow-[oklch(0.6666_0.368_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5334)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.245_262.881_/_0.7334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/light
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/light
@@ -113,20 +113,20 @@
         "class": "bg-[oklch(0.9933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[15px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_4px]",
         "children": {
           "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_4px]",
-          "20 (2)": "bg-[oklch(0.7933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[4px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
+          "20 (2)": "bg-[oklch(0.7933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[4px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
           "skip": {
             "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] p-[4px]",
             "children": {
-              "host": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[7px] border-[4px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+              "host": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[7px] border-[4px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "zero": {
             "class": "bg-[oklch(0.9933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] p-[4px]",
             "children": {
-              "host": "bg-[oklch(0.7933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[7px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+              "host": "bg-[oklch(0.7933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[7px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
-          "host": "bg-[oklch(0.7933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[4px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+          "host": "bg-[oklch(0.7933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[4px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]"
         }
       },
       "raw mix": "bg-[oklch(0.7377_0.0971_30.0506)] text-[oklch(0_0_0)] *:text-[lch(18.2327_35.22_34.184)] rounded-[15px] border-[1px] border-[oklch(0_0.0971_30.0506_/_0.1)] p-[4px]",
@@ -251,32 +251,32 @@
             "class": "bg-[oklch(0.9933_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.1)] border-b-[oklch(0_0.0011_197.14_/_0.1)] border-l-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.9933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.8933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.7933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.7251_0.368_197.14)] p-[4px] shadow-[oklch(0.7251_0.368_197.14)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.4933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.3933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.2933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.1933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0.0933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.8933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.7933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.7251_0.368_197.14)] p-[4px] shadow-[oklch(0.7251_0.368_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.4933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.3933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.2933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.1933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.0933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.3_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.3_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.4_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.5_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.4_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.5_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -446,32 +446,32 @@
             "class": "bg-[oklch(0.8933_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.1)] border-b-[oklch(0_0.0011_197.14_/_0.1)] border-l-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.8933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.7933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.5498_0.368_197.14)] p-[4px] shadow-[oklch(0.5498_0.368_197.14)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.4933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.3933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.2933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.1933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.0933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.7933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.5498_0.368_197.14)] p-[4px] shadow-[oklch(0.5498_0.368_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.4933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.3933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.2933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.1933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.0933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.3_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.3_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.4_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.5_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.4_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.5_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -641,32 +641,32 @@
             "class": "bg-[oklch(0.7933_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.1)] border-b-[oklch(0_0.0011_197.14_/_0.1)] border-l-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.7933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4933_0.368_197.14)] p-[4px] shadow-[oklch(0.4933_0.368_197.14)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.3933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.1933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.0933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4933_0.368_197.14)] p-[4px] shadow-[oklch(0.4933_0.368_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.0933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.3_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.3_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.4_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.5_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.4_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.5_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -836,32 +836,32 @@
             "class": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.1)] border-b-[oklch(0_0.0011_197.14_/_0.1)] border-l-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.5251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4251_0.368_197.14)] p-[4px] shadow-[oklch(0.4251_0.368_197.14)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.3251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.1251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.0251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.5251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4251_0.368_197.14)] p-[4px] shadow-[oklch(0.4251_0.368_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.0251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.3_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.3_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.4_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.5_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.4_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.5_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -1031,32 +1031,32 @@
             "class": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.1)] border-b-[oklch(0_0.0011_197.14_/_0.1)] border-l-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.5251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4251_0.368_197.14)] p-[4px] shadow-[oklch(0.4251_0.368_197.14)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.3251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.1251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.0251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.5251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4251_0.368_197.14)] p-[4px] shadow-[oklch(0.4251_0.368_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.0251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.3_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.3_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.4_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.5_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.4_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.5_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -1226,32 +1226,32 @@
             "class": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0011_197.14_/_0.1)] border-b-[oklch(1_0.0011_197.14_/_0.1)] border-l-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.5251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4251_0.368_197.14)] p-[4px] shadow-[oklch(0.4251_0.368_197.14)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.3251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.1251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.0251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.5251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4251_0.368_197.14)] p-[4px] shadow-[oklch(0.4251_0.368_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.0251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.3_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.3_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.4_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.5_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.4_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.5_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -1421,32 +1421,32 @@
             "class": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0011_197.14_/_0.1)] border-b-[oklch(1_0.0011_197.14_/_0.1)] border-l-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.5251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4251_0.368_197.14)] p-[4px] shadow-[oklch(0.4251_0.368_197.14)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.3251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.1251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.0251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.5251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4251_0.368_197.14)] p-[4px] shadow-[oklch(0.4251_0.368_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.0251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.3_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.3_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.4_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.5_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.4_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.5_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -1616,32 +1616,32 @@
             "class": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0011_197.14_/_0.1)] border-b-[oklch(1_0.0011_197.14_/_0.1)] border-l-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.5251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4251_0.368_197.14)] p-[4px] shadow-[oklch(0.4251_0.368_197.14)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.3251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.1251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.0251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.5251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4251_0.368_197.14)] p-[4px] shadow-[oklch(0.4251_0.368_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.0251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.2933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.2933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.3933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.4933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.7933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.8933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.9933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.3933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.4933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.7933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.8933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.9933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -1811,32 +1811,32 @@
             "class": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0011_197.14_/_0.1)] border-b-[oklch(1_0.0011_197.14_/_0.1)] border-l-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.5251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4251_0.368_197.14)] p-[4px] shadow-[oklch(0.4251_0.368_197.14)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.3251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.1251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.0251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.5251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4251_0.368_197.14)] p-[4px] shadow-[oklch(0.4251_0.368_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.0251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.1933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.1933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.2933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.3933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.7933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.8933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.9933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.2933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.3933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.7933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.8933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.9933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -2006,32 +2006,32 @@
             "class": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0011_197.14_/_0.1)] border-b-[oklch(1_0.0011_197.14_/_0.1)] border-l-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.5251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4251_0.368_197.14)] p-[4px] shadow-[oklch(0.4251_0.368_197.14)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.3251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.1251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.0251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.5251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4251_0.368_197.14)] p-[4px] shadow-[oklch(0.4251_0.368_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.0251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.0933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.0933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.23_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.33_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.43_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.53_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.73_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.83_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.93_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.23_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.33_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.43_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.53_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.73_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.83_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.93_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -2201,32 +2201,32 @@
             "class": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0011_197.14_/_0.1)] border-b-[oklch(1_0.0011_197.14_/_0.1)] border-l-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.5251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4251_0.368_197.14)] p-[4px] shadow-[oklch(0.4251_0.368_197.14)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.3251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.1251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.0251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.5251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4251_0.368_197.14)] p-[4px] shadow-[oklch(0.4251_0.368_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.0251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.23_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.33_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.43_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.53_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.73_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.83_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.93_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.23_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.33_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.43_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.53_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.73_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.83_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.93_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -2401,32 +2401,32 @@
             "class": "bg-[oklch(0.9933_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.1)] border-b-[oklch(0_0.0011_197.14_/_0.1)] border-l-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.9933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.8933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.7933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.7251_0.368_197.14)] p-[4px] shadow-[oklch(0.7251_0.368_197.14)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.4933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.3933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.2933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.1933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0.0933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.8933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.7933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.7251_0.368_197.14)] p-[4px] shadow-[oklch(0.7251_0.368_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.4933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.3933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.2933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.1933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.0933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.3_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.3_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.4_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.5_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.4_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.5_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -2596,32 +2596,32 @@
             "class": "bg-[oklch(0.8933_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.1)] border-b-[oklch(0_0.0011_197.14_/_0.1)] border-l-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.8933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.7933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.5498_0.368_197.14)] p-[4px] shadow-[oklch(0.5498_0.368_197.14)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.4933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.3933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.2933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.1933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.0933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.7933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.5498_0.368_197.14)] p-[4px] shadow-[oklch(0.5498_0.368_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.4933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.3933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.2933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.1933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.0933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.3_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.3_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.4_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.5_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.4_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.5_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -2791,32 +2791,32 @@
             "class": "bg-[oklch(0.7933_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.1)] border-b-[oklch(0_0.0011_197.14_/_0.1)] border-l-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.7933_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4933_0.368_197.14)] p-[4px] shadow-[oklch(0.4933_0.368_197.14)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.3933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.1933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.0933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4933_0.368_197.14)] p-[4px] shadow-[oklch(0.4933_0.368_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.0933_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.3_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.3_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.4_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.5_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.4_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.5_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -2986,32 +2986,32 @@
             "class": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.1)] border-b-[oklch(0_0.0011_197.14_/_0.1)] border-l-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.5251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4251_0.368_197.14)] p-[4px] shadow-[oklch(0.4251_0.368_197.14)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.3251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.1251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.0251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.5251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4251_0.368_197.14)] p-[4px] shadow-[oklch(0.4251_0.368_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.0251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.3_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.3_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.4_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.5_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.4_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.5_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -3181,32 +3181,32 @@
             "class": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.1)] border-b-[oklch(0_0.0011_197.14_/_0.1)] border-l-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.5251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4251_0.368_197.14)] p-[4px] shadow-[oklch(0.4251_0.368_197.14)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.3251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.1251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.0251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.5251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4251_0.368_197.14)] p-[4px] shadow-[oklch(0.4251_0.368_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.0251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.3_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.3_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.4_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.5_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.4_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.5_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -3376,32 +3376,32 @@
             "class": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0011_197.14_/_0.1)] border-b-[oklch(1_0.0011_197.14_/_0.1)] border-l-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.7251_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.5251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4251_0.368_197.14)] p-[4px] shadow-[oklch(0.4251_0.368_197.14)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.3251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.1251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.0251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.5251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4251_0.368_197.14)] p-[4px] shadow-[oklch(0.4251_0.368_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.0251_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.23_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.33_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.43_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.53_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.73_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.83_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.93_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.23_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.33_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.43_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.53_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.5498_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.73_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.83_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.93_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -3576,32 +3576,32 @@
             "class": "bg-[oklch(0.725_0_0)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0_0_/_0.1)] border-b-[oklch(1_0_0_/_0.1)] border-l-[oklch(1_0_0_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.725_0_0)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0_0_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.55_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.525_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0_0_/_0.5)] p-[4px] shadow-[oklch(1_0_0_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.425_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.425_0.368_0)] p-[4px] shadow-[oklch(0.425_0.368_0)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.325_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.225_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.125_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.025_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.55_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.525_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0_0_/_0.5)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.425_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.425_0.368_0)] p-[4px] shadow-[oklch(0.425_0.368_0_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.325_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.225_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.125_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.025_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0_0_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.23_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.33_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.43_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.53_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.55_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.73_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.83_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.93_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0_0_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.23_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.33_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.43_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.53_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.55_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.73_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.83_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.93_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -3771,32 +3771,32 @@
             "class": "bg-[oklch(0.725_0_0)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0_0_/_0.1)] border-b-[oklch(1_0_0_/_0.1)] border-l-[oklch(1_0_0_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.725_0_0)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0_0_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.55_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.525_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0_0_/_0.5)] p-[4px] shadow-[oklch(1_0_0_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.425_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.425_0.368_0)] p-[4px] shadow-[oklch(0.425_0.368_0)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.325_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.225_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.125_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.025_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.55_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.525_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0_0_/_0.5)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.425_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.425_0.368_0)] p-[4px] shadow-[oklch(0.425_0.368_0_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.325_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.225_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.125_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.025_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.1)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.05_0_0)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.05_0_0)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0_0_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.23_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.33_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.43_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.53_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.55_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.73_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.83_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.93_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0_0_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.23_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.33_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.43_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.53_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.55_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.73_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.83_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.93_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0_0_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -3966,32 +3966,32 @@
             "class": "bg-[oklch(0.7272_0.02_260)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.02_260_/_0.1)] border-b-[oklch(1_0.02_260_/_0.1)] border-l-[oklch(1_0.02_260_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.7272_0.02_260)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.02_260_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.5455_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.1)] p-[4px] shadow-[oklch(0_0.02_260_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.5272_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.02_260_/_0.5)] p-[4px] shadow-[oklch(1_0.02_260_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4272_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4272_0.368_260)] p-[4px] shadow-[oklch(0.4272_0.368_260)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.3272_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.1)] p-[4px] shadow-[oklch(0_0.02_260_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2272_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.1)] p-[4px] shadow-[oklch(0_0.02_260_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.1272_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.1)] p-[4px] shadow-[oklch(0_0.02_260_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.0272_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.1)] p-[4px] shadow-[oklch(0_0.02_260_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.1)] p-[4px] shadow-[oklch(0_0.02_260_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.1)] p-[4px] shadow-[oklch(0_0.02_260_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.1)] p-[4px] shadow-[oklch(0_0.02_260_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.5455_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.1)] p-[4px] shadow-[oklch(0_0.02_260_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.5272_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.02_260_/_0.5)] p-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4272_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4272_0.368_260)] p-[4px] shadow-[oklch(0.4272_0.368_260_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3272_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.1)] p-[4px] shadow-[oklch(0_0.02_260_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2272_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.1)] p-[4px] shadow-[oklch(0_0.02_260_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1272_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.1)] p-[4px] shadow-[oklch(0_0.02_260_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.0272_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.1)] p-[4px] shadow-[oklch(0_0.02_260_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.1)] p-[4px] shadow-[oklch(0_0.02_260_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.1)] p-[4px] shadow-[oklch(0_0.02_260_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.1)] p-[4px] shadow-[oklch(0_0.02_260_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.08_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.08_0.02_260)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.02_260_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.23_0.02_260)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.1)] p-[4px] shadow-[oklch(1_0.02_260_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.33_0.02_260)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.1)] p-[4px] shadow-[oklch(1_0.02_260_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.43_0.02_260)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.1)] p-[4px] shadow-[oklch(1_0.02_260_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.53_0.02_260)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.1)] p-[4px] shadow-[oklch(1_0.02_260_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.5455_0.02_260)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.1)] p-[4px] shadow-[oklch(1_0.02_260_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.73_0.02_260)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.1)] p-[4px] shadow-[oklch(1_0.02_260_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.83_0.02_260)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.1)] p-[4px] shadow-[oklch(1_0.02_260_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.93_0.02_260)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.1)] p-[4px] shadow-[oklch(1_0.02_260_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.1)] p-[4px] shadow-[oklch(1_0.02_260_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.02_260_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.02_260_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.23_0.02_260)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.1)] p-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.33_0.02_260)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.1)] p-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.43_0.02_260)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.1)] p-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.53_0.02_260)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.1)] p-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.5455_0.02_260)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.1)] p-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.73_0.02_260)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.1)] p-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.83_0.02_260)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.1)] p-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.93_0.02_260)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.1)] p-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.1)] p-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.02_260_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -4166,32 +4166,32 @@
             "class": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.245_262.881_/_0.1)] border-b-[oklch(1_0.245_262.881_/_0.1)] border-l-[oklch(1_0.245_262.881_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.5)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4525_0.368_262.881)] p-[4px] shadow-[oklch(0.4525_0.368_262.881)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.3525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.1525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.0525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.5)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4525_0.368_262.881)] p-[4px] shadow-[oklch(0.4525_0.368_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.0525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.3_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.3_0.245_262.881)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.245_262.881_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.4_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.4_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -4361,32 +4361,32 @@
             "class": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.245_262.881_/_0.1)] border-b-[oklch(1_0.245_262.881_/_0.1)] border-l-[oklch(1_0.245_262.881_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.5)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4525_0.368_262.881)] p-[4px] shadow-[oklch(0.4525_0.368_262.881)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.3525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.1525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.0525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.5)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4525_0.368_262.881)] p-[4px] shadow-[oklch(0.4525_0.368_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.0525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.3_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.3_0.245_262.881)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.245_262.881_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.4_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.4_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -4556,32 +4556,32 @@
             "class": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.245_262.881_/_0.1)] border-b-[oklch(1_0.245_262.881_/_0.1)] border-l-[oklch(1_0.245_262.881_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.5)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4525_0.368_262.881)] p-[4px] shadow-[oklch(0.4525_0.368_262.881)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.3525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.1525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.0525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.5)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4525_0.368_262.881)] p-[4px] shadow-[oklch(0.4525_0.368_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.0525_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.245_262.881_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.3951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.7951_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.8951_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.9951_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.3951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.7951_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.8951_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.9951_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -4751,32 +4751,32 @@
             "class": "bg-[oklch(0.7951_0.245_262.881)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.245_262.881_/_0.1)] border-b-[oklch(0_0.245_262.881_/_0.1)] border-l-[oklch(0_0.245_262.881_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.7951_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.5)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4951_0.368_262.881)] p-[4px] shadow-[oklch(0.4951_0.368_262.881)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.3951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.1951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.0951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.5)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4951_0.368_262.881)] p-[4px] shadow-[oklch(0.4951_0.368_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.0951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.3_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.3_0.245_262.881)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.245_262.881_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.4_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.4_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -4946,32 +4946,32 @@
             "class": "bg-[oklch(0.8951_0.245_262.881)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.245_262.881_/_0.1)] border-b-[oklch(0_0.245_262.881_/_0.1)] border-l-[oklch(0_0.245_262.881_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.8951_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.7951_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.5)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4951_0.368_262.881)] p-[4px] shadow-[oklch(0.4951_0.368_262.881)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.3951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.1951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.0951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.7951_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.5)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.4951_0.368_262.881)] p-[4px] shadow-[oklch(0.4951_0.368_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.3951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.1951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.0951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.3_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.3_0.245_262.881)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.245_262.881_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.4_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.4_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -5141,32 +5141,32 @@
             "class": "bg-[oklch(0.9951_0.245_262.881)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.245_262.881_/_0.1)] border-b-[oklch(0_0.245_262.881_/_0.1)] border-l-[oklch(0_0.245_262.881_/_0.1)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.9951_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.8951_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.7951_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.5)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.7525_0.368_262.881)] p-[4px] shadow-[oklch(0.7525_0.368_262.881)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.3951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.1951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0.0951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.8951_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.7951_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.5)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.7525_0.368_262.881)] p-[4px] shadow-[oklch(0.7525_0.368_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.3951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.2951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.1951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.0951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.3_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.2)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.3_0.245_262.881)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.245_262.881_/_0.4)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.4_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0.1)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.4_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4951_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.7525_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.1)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {

--- a/app/src/sandbox/ariakit-tailwind/__snapshots__/light-high-contrast
+++ b/app/src/sandbox/ariakit-tailwind/__snapshots__/light-high-contrast
@@ -89,7 +89,7 @@
             }
           },
           "inherit skip": {
-            "class": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.3334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.3334)_0px_0px_0px_0px]",
+            "class": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(1_0.245_262.881_/_0.3334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
             "children": {
               "host": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[5px] border-[1px] border-[oklch(0_0.245_27.325_/_0.7334)] p-[4px]"
             }
@@ -113,20 +113,20 @@
         "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[15px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_4px]",
         "children": {
           "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_4px]",
-          "20 (2)": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[4px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
+          "20 (2)": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[4px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
           "skip": {
             "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] p-[4px]",
             "children": {
-              "host": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[7px] border-[4px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]"
+              "host": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[7px] border-[4px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "zero": {
             "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] p-[4px]",
             "children": {
-              "host": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[7px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]"
+              "host": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[7px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
-          "host": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[4px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]"
+          "host": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[11px] border-[4px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]"
         }
       },
       "raw mix": "bg-[oklch(1_0.0971_30.0506)] text-[oklch(0_0_0)] *:text-[lch(0_34.87_33.938)] rounded-[15px] border-[1px] border-[oklch(0_0.0971_30.0506_/_0.4334)] p-[4px]",
@@ -251,32 +251,32 @@
             "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.4334)] border-b-[oklch(0_0.0011_197.14_/_0.4334)] border-l-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.8334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.8334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_197.14)] p-[4px] shadow-[oklch(0.6666_0.368_197.14)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.8334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_197.14)] p-[4px] shadow-[oklch(0.6666_0.368_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.5334)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.7334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -446,32 +446,32 @@
             "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.4334)] border-b-[oklch(0_0.0011_197.14_/_0.4334)] border-l-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.8334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.8334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_197.14)] p-[4px] shadow-[oklch(0.6666_0.368_197.14)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.8334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_197.14)] p-[4px] shadow-[oklch(0.6666_0.368_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.5334)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.7334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -641,32 +641,32 @@
             "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.4334)] border-b-[oklch(0_0.0011_197.14_/_0.4334)] border-l-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.8334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.8334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_197.14)] p-[4px] shadow-[oklch(0.6666_0.368_197.14)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.8334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_197.14)] p-[4px] shadow-[oklch(0.6666_0.368_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.5334)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.7334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -836,32 +836,32 @@
             "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.4334)] border-b-[oklch(0_0.0011_197.14_/_0.4334)] border-l-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.8334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.8334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_197.14)] p-[4px] shadow-[oklch(0.6666_0.368_197.14)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.8334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_197.14)] p-[4px] shadow-[oklch(0.6666_0.368_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.5334)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.7334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -1031,32 +1031,32 @@
             "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.4334)] border-b-[oklch(0_0.0011_197.14_/_0.4334)] border-l-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.8334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.8334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_197.14)] p-[4px] shadow-[oklch(0.6666_0.368_197.14)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.8334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_197.14)] p-[4px] shadow-[oklch(0.6666_0.368_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.5334)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.7334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -1226,32 +1226,32 @@
             "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.4334)] border-b-[oklch(0_0.0011_197.14_/_0.4334)] border-l-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.8334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.8334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_197.14)] p-[4px] shadow-[oklch(0.6666_0.368_197.14)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.8334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_197.14)] p-[4px] shadow-[oklch(0.6666_0.368_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.5334)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.7334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -1421,32 +1421,32 @@
             "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.4334)] border-b-[oklch(0_0.0011_197.14_/_0.4334)] border-l-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.8334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.8334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_197.14)] p-[4px] shadow-[oklch(0.6666_0.368_197.14)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.8334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_197.14)] p-[4px] shadow-[oklch(0.6666_0.368_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.5334)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.7334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -1616,32 +1616,32 @@
             "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.4334)] border-b-[oklch(0_0.0011_197.14_/_0.4334)] border-l-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.8334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.8334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_197.14)] p-[4px] shadow-[oklch(0.6666_0.368_197.14)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.8334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_197.14)] p-[4px] shadow-[oklch(0.6666_0.368_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.5334)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.7334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -1811,32 +1811,32 @@
             "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0011_197.14_/_0.4334)] border-b-[oklch(1_0.0011_197.14_/_0.4334)] border-l-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.8334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.8334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_197.14)] p-[4px] shadow-[oklch(0.6666_0.368_197.14)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.8334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_197.14)] p-[4px] shadow-[oklch(0.6666_0.368_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5334)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.7334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -2006,32 +2006,32 @@
             "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0011_197.14_/_0.4334)] border-b-[oklch(1_0.0011_197.14_/_0.4334)] border-l-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.8334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.8334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_197.14)] p-[4px] shadow-[oklch(0.6666_0.368_197.14)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.8334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_197.14)] p-[4px] shadow-[oklch(0.6666_0.368_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5334)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.7334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -2201,32 +2201,32 @@
             "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0011_197.14_/_0.4334)] border-b-[oklch(1_0.0011_197.14_/_0.4334)] border-l-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.8334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.8334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_197.14)] p-[4px] shadow-[oklch(0.6666_0.368_197.14)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.8334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_197.14)] p-[4px] shadow-[oklch(0.6666_0.368_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0666_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5334)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.7334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1966_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -2401,32 +2401,32 @@
             "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.1834)] border-b-[oklch(0_0.0011_197.14_/_0.1834)] border-l-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.5834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.7834_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.7_0.368_197.14)] p-[4px] shadow-[oklch(0.7_0.368_197.14)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.4167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.3167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.2167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.1167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0.0167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.7834_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.7_0.368_197.14)] p-[4px] shadow-[oklch(0.7_0.368_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.4167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.3167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.2167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.1167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.0167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.2167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.2834)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.1333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.4834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.2333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.3333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.2333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.3333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -2596,32 +2596,32 @@
             "class": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.1834)] border-b-[oklch(0_0.0011_197.14_/_0.1834)] border-l-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.5834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.7834_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.7_0.368_197.14)] p-[4px] shadow-[oklch(0.7_0.368_197.14)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.4167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.3167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.2167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.1167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0.0167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.9834_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.8834_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.7834_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.7_0.368_197.14)] p-[4px] shadow-[oklch(0.7_0.368_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.4167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.3167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.2167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.1167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0.0167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.2167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.2834)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.1333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.4834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.2333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.3333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.2333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.3333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -2791,32 +2791,32 @@
             "class": "bg-[oklch(0.9667_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.1834)] border-b-[oklch(0_0.0011_197.14_/_0.1834)] border-l-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.9501_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.8501_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.5834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.7689_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6855_0.368_197.14)] p-[4px] shadow-[oklch(0.6855_0.368_197.14)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.3834_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.2834_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.1834_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.0833_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.9501_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.8501_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.7689_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6855_0.368_197.14)] p-[4px] shadow-[oklch(0.6855_0.368_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.3834_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.2834_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.1834_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.0833_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.2167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.2834)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.1333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.4834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.2333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.3333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.2333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.3333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -2986,32 +2986,32 @@
             "class": "bg-[oklch(0.9356_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.1834)] border-b-[oklch(0_0.0011_197.14_/_0.1834)] border-l-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.9189_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.8189_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.5834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.3789_0.368_197.14)] p-[4px] shadow-[oklch(0.3789_0.368_197.14)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.4522_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.3522_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.2522_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.1522_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.0522_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.9189_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.8189_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.3789_0.368_197.14)] p-[4px] shadow-[oklch(0.3789_0.368_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.4522_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.3522_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.2522_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.1522_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.0522_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.2167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.2834)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.1333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.4834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.2333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.3333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.2333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.3333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -3181,32 +3181,32 @@
             "class": "bg-[oklch(0.9356_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(0_0.0011_197.14_/_0.1834)] border-b-[oklch(0_0.0011_197.14_/_0.1834)] border-l-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.9189_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.8189_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.5834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.3789_0.368_197.14)] p-[4px] shadow-[oklch(0.3789_0.368_197.14)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.4522_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.3522_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.2522_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.1522_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0.0522_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.9189_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.8189_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.3789_0.368_197.14)] p-[4px] shadow-[oklch(0.3789_0.368_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.4522_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.3522_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.2522_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.1522_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0.0522_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0.2167_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.2834)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0.1333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.4834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.2333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.3333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.2333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.3333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4333_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.8_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.9_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -3376,32 +3376,32 @@
             "class": "bg-[oklch(0.7834_0.0011_197.14)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.0011_197.14_/_0.1834)] border-b-[oklch(1_0.0011_197.14_/_0.1834)] border-l-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(0.8667_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.7689_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.5834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.4_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.3167_0.368_197.14)] p-[4px] shadow-[oklch(0.3167_0.368_197.14)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.3_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.1_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.7689_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.0011_197.14_/_0.5834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.4_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0.3167_0.368_197.14)] p-[4px] shadow-[oklch(0.3167_0.368_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.3_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.1_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(0_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.2834)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.0011_197.14)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.0011_197.14_/_0.4834)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0.1467_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0.2467_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.3467_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.4467_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.8134_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0.9134_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0.1834)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0.1467_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0.2467_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.3467_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.4467_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.4623_0.0011_197.14)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.8134_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0.9134_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.0011_197.14)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.0011_197.14_/_0.1834)] p-[4px] m-[4px] shadow-[oklch(1_0.0011_197.14_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -3576,32 +3576,32 @@
             "class": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0_0_/_0.4334)] border-b-[oklch(1_0_0_/_0.4334)] border-l-[oklch(1_0_0_/_0.4334)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0_0_/_0.4334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0_0_/_0.8334)] p-[4px] shadow-[oklch(1_0_0_/_0.8334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_0)] p-[4px] shadow-[oklch(0.6666_0.368_0)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0666_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0_0_/_0.8334)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_0)] p-[4px] shadow-[oklch(0.6666_0.368_0_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1666_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0666_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5334)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0_0_/_0.7334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1966_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0_0_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0966_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1966_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -3771,32 +3771,32 @@
             "class": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0_0_/_0.4334)] border-b-[oklch(1_0_0_/_0.4334)] border-l-[oklch(1_0_0_/_0.4334)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0_0_/_0.4334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0_0_/_0.8334)] p-[4px] shadow-[oklch(1_0_0_/_0.8334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_0)] p-[4px] shadow-[oklch(0.6666_0.368_0)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0666_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0_0_/_0.8334)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_0)] p-[4px] shadow-[oklch(0.6666_0.368_0_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1666_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0666_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0_0_/_0.4334)] p-[4px] shadow-[oklch(0_0_0_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5334)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0_0_/_0.7334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1966_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0_0_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0966_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1966_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0_0)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0_0)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0_0_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0_0_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -3966,32 +3966,32 @@
             "class": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.02_260_/_0.4334)] border-b-[oklch(1_0.02_260_/_0.4334)] border-l-[oklch(1_0.02_260_/_0.4334)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.02_260_/_0.4334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(0_0.02_260_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.02_260_/_0.8334)] p-[4px] shadow-[oklch(1_0.02_260_/_0.8334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_260)] p-[4px] shadow-[oklch(0.6666_0.368_260)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(0_0.02_260_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(0_0.02_260_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0666_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(0_0.02_260_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(0_0.02_260_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(0_0.02_260_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(0_0.02_260_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(0_0.02_260_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(0_0.02_260_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.02_260_/_0.8334)] p-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_260)] p-[4px] shadow-[oklch(0.6666_0.368_260_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(0_0.02_260_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1666_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(0_0.02_260_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0666_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(0_0.02_260_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(0_0.02_260_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(0_0.02_260_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(0_0.02_260_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(0_0.02_260_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0.02_260)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5334)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.02_260)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.02_260_/_0.7334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0_0.02_260)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(1_0.02_260_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.02_260)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(1_0.02_260_/_0.4334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0.02_260)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(1_0.02_260_/_0.4334)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1966_0.02_260)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(1_0.02_260_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.02_260)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(1_0.02_260_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(1_0.02_260_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(1_0.02_260_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(1_0.02_260_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(1_0.02_260_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.02_260_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.02_260_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0_0.02_260)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0_0.02_260)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0966_0.02_260)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1966_0.02_260)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.02_260)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.02_260_/_0.4334)] p-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.02_260)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.02_260_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.02_260_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -4166,32 +4166,32 @@
             "class": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.245_262.881_/_0.4334)] border-b-[oklch(1_0.245_262.881_/_0.4334)] border-l-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.8334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.8334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_262.881)] p-[4px] shadow-[oklch(0.6666_0.368_262.881)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.8334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_262.881)] p-[4px] shadow-[oklch(0.6666_0.368_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5334)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.245_262.881_/_0.7334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -4361,32 +4361,32 @@
             "class": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.245_262.881_/_0.4334)] border-b-[oklch(1_0.245_262.881_/_0.4334)] border-l-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.8334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.8334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_262.881)] p-[4px] shadow-[oklch(0.6666_0.368_262.881)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.8334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_262.881)] p-[4px] shadow-[oklch(0.6666_0.368_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5334)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.245_262.881_/_0.7334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -4556,32 +4556,32 @@
             "class": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.245_262.881_/_0.4334)] border-b-[oklch(1_0.245_262.881_/_0.4334)] border-l-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.8334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.8334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_262.881)] p-[4px] shadow-[oklch(0.6666_0.368_262.881)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.8334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_262.881)] p-[4px] shadow-[oklch(0.6666_0.368_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5334)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.245_262.881_/_0.7334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -4751,32 +4751,32 @@
             "class": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.245_262.881_/_0.4334)] border-b-[oklch(1_0.245_262.881_/_0.4334)] border-l-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.8334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.8334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_262.881)] p-[4px] shadow-[oklch(0.6666_0.368_262.881)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.8334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_262.881)] p-[4px] shadow-[oklch(0.6666_0.368_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5334)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.245_262.881_/_0.7334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -4946,32 +4946,32 @@
             "class": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.245_262.881_/_0.4334)] border-b-[oklch(1_0.245_262.881_/_0.4334)] border-l-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.8334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.8334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_262.881)] p-[4px] shadow-[oklch(0.6666_0.368_262.881)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.8334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_262.881)] p-[4px] shadow-[oklch(0.6666_0.368_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5334)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.245_262.881_/_0.7334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {
@@ -5141,32 +5141,32 @@
             "class": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] border-r-[1px] border-b-[1px] border-l-[1px] border-r-[oklch(1_0.245_262.881_/_0.4334)] border-b-[oklch(1_0.245_262.881_/_0.4334)] border-l-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] mr-[-5px] ml-[-5px]",
             "children": {
               "0": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.8334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.8334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_262.881)] p-[4px] shadow-[oklch(0.6666_0.368_262.881)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.1666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(0.0666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[4px] border-[oklch(1_0.245_262.881_/_0.8334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[10px] border-[1px] border-[oklch(0.6666_0.368_262.881)] p-[4px] shadow-[oklch(0.6666_0.368_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.1666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(0.0666_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] border-[1px] border-[oklch(0_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(0_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-lighten-<number>": {
             "class": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[10px] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.5334)_0px_0px_0px_2px]",
             "children": {
               "0": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-bl-[10px] p-[4px] mt-[-4px] mb-[-4px] ml-[-4px] shadow-[oklch(1_0.245_262.881_/_0.7334)_0px_0px_0px_1px]",
-              "10": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "20": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "30": "bg-[oklch(0.0966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "40": "bg-[oklch(0.1966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "50": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "60": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]",
-              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0.4334)_0px_0px_0px_0px]"
+              "10": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "20": "bg-[oklch(0_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "30": "bg-[oklch(0.0966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "40": "bg-[oklch(0.1966_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "50": "bg-[oklch(0.2_0.245_262.881)] text-[oklch(1_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "60": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "70": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "80": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "90": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[6px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]",
+              "100": "bg-[oklch(1_0.245_262.881)] text-[oklch(0_0_0)] rounded-[2px] border-[1px] border-[oklch(1_0.245_262.881_/_0.4334)] p-[4px] m-[4px] shadow-[oklch(1_0.245_262.881_/_0)_0px_0px_0px_0px]"
             }
           },
           "ak-layer-push-<number>": {

--- a/packages/ariakit-tailwind/src/input.ts
+++ b/packages/ariakit-tailwind/src/input.ts
@@ -2193,8 +2193,23 @@ function getFrameBorderingContextDeclarations() {
  * shadow on a rounded box as faint arcs at its corners. The width comes from
  * `ak-frame`, so the rule order between the two utilities does not matter.
  */
-function getFrameRingDeclarations() {
-  return at.apply`ring-[length:${vars.frameRing}]`;
+function getFrameRingDeclarations(transparentWhenZero = false) {
+  const declarations = [at.apply`ring-[length:${vars.frameRing}]`];
+  if (!transparentWhenZero) return declarations;
+  // Firefox can paint a colored zero-width shadow at rounded corners. Gate only
+  // its alpha so nonzero rings retain their color and other shadows.
+  const color = fn.oklch(
+    "var(--tw-ring-color, --theme(--default-ring-color, currentColor))",
+    { a: fn.mul(alpha, fn.exp`sign(${vars.frameRing})`) },
+  );
+  const spread = fn.add(vars.frameRing, "var(--tw-ring-offset-width)");
+  return [
+    ...declarations,
+    set(
+      "--tw-ring-shadow",
+      fn.exp`var(--tw-ring-inset,) 0 0 0 ${spread} ${color}`,
+    ),
+  ];
 }
 
 function getLayerEdgeContextDeclarations() {
@@ -2542,14 +2557,14 @@ utility(
   "frame-bordering",
   set(inputs.frameBordering, "1px"),
   getFrameBorderingDarkLight(),
-  getFrameRingDeclarations(),
+  getFrameRingDeclarations(true),
   getFrameBorderingContextDeclarations(),
   getLayerEdgeContextDeclarations(),
 );
 
 utility(
   "frame-bordering-inherit",
-  getFrameRingDeclarations(),
+  getFrameRingDeclarations(true),
   frameContext.read(({ inherit }) => [
     set(
       inputs.frameBordering,
@@ -2566,7 +2581,7 @@ utility(
   "frame-bordering-*",
   getFrameBorderWidthDeclarations(inputs.frameBordering),
   getFrameBorderingDarkLight(),
-  getFrameRingDeclarations(),
+  getFrameRingDeclarations(true),
   getFrameBorderingContextDeclarations(),
   getLayerEdgeContextDeclarations(),
 );

--- a/packages/ariakit-tailwind/src/output.css
+++ b/packages/ariakit-tailwind/src/output.css
@@ -1268,6 +1268,7 @@
     --_ak-frame-ring: calc((1 - var(--_ak-fbd)) * var(--_ak-frame-bordering));
   }
   @apply ring-[length:var(--ak-frame-ring)];
+  --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(var(--ak-frame-ring) + var(--tw-ring-offset-width)) oklch(from var(--tw-ring-color, --theme(--default-ring-color, currentColor)) l c h / calc(alpha * sign(var(--ak-frame-ring))));
   --_ak-frame-bordering-context: 1;
   @container (style(--_context-1: even)) or (not style(--_context-1)) {
     --_context-1: odd;
@@ -1283,6 +1284,7 @@
 
 @utility ak-frame-bordering-inherit {
   @apply ring-[length:var(--ak-frame-ring)];
+  --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(var(--ak-frame-ring) + var(--tw-ring-offset-width)) oklch(from var(--tw-ring-color, --theme(--default-ring-color, currentColor)) l c h / calc(alpha * sign(var(--ak-frame-ring))));
   @container (style(--_context-2: even)) or (not style(--_context-2)) {
     --_ak-frame-bordering: max(var(--_ak-fpbbc-even, 0px), var(--_ak-fpbgc-even, 0px));
     --_ak-fbd: clamp(0, ((var(--_ak-layer-idle-relative-lightness) * -1) * 1000000), 1);
@@ -1328,6 +1330,7 @@
     --_ak-frame-ring: calc((1 - var(--_ak-fbd)) * var(--_ak-frame-bordering));
   }
   @apply ring-[length:var(--ak-frame-ring)];
+  --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(var(--ak-frame-ring) + var(--tw-ring-offset-width)) oklch(from var(--tw-ring-color, --theme(--default-ring-color, currentColor)) l c h / calc(alpha * sign(var(--ak-frame-ring))));
   --_ak-frame-bordering-context: 1;
   @container (style(--_context-1: even)) or (not style(--_context-1)) {
     --_context-1: odd;


### PR DESCRIPTION
## Motivation

Adaptive frame borders leave a colored zero-width ring shadow when they select a border. Firefox can paint that shadow around rounded corners. Fixes #7470.

## Solution

Make the adaptive ring shadow transparent when its ring width is zero. Keep the ring color and alpha for positive widths, and preserve Tailwind's ring inset, offset, theme color, and shadow composition. The calculation uses CSS `sign()` and relative color alpha; it does not depend on CSS `if()`.

For example, this recessed surface keeps its border without the extra corner paint:

```tsx
<div className="ak-layer ak-layer-darken-30 ak-frame ak-frame-bordering" />
```

The same fix applies to explicit widths such as `ak-frame-bordering-4` and to `ak-frame-bordering-inherit`.

## Verification

- Chrome and Firefox checks cover light and dark schemes, explicit lightening and darkening, inherited widths, fractional and zero widths, custom and theme ring colors, inset rings, composed shadows, and focus rings with offsets.
- The focused regression tests and all four broad computed-style snapshots fail with the original CSS and pass with the fix. A structural comparison confirms that the broad snapshots change only the alpha of zero-width rings.
- In the reported Firefox frame, the border stays at `1px` and the radius stays at `10px`. Removing its ring term after the fix causes no pixel changes.
- Package build, lint, and TypeScript checks pass.

## Preview

The comparison shows the reported row in Firefox before and after the fix. The corner views use the original screenshot colors, enlarged without smoothing.

![Firefox adaptive frame borders before and after suppressing zero-width ring paint](https://github.com/user-attachments/assets/da7c6f33-da5a-4e5d-aa11-e299e80acd30)
