### PR TITLE
Update oxlint-plugin-comment-reflow to 0.2.0

### DIFF
--- a/app/src/pages/ariakit-ui/_ariakit-ui/dialog.react.tsx
+++ b/app/src/pages/ariakit-ui/_ariakit-ui/dialog.react.tsx
@@ -58,9 +58,9 @@ function OpenDialog({
   return (
     <Layer
       $lightnessOffset
-      // Layout containment is what makes the stage the containing block of
-      // the fixed dialog and backdrop; container-type alone stopped implying
-      // it, and only sizes the dialog's viewport units.
+      // Layout containment is what makes the stage the containing block of the
+      // fixed dialog and backdrop; container-type alone stopped implying it,
+      // and only sizes the dialog's viewport units.
       className={clsx(
         "relative h-72 overflow-clip rounded-xl p-4 contain-layout [container-type:size]",
         stageClassName,

--- a/app/src/pages/ariakit-ui/_ariakit-ui/select.react.tsx
+++ b/app/src/pages/ariakit-ui/_ariakit-ui/select.react.tsx
@@ -96,8 +96,8 @@ function OpenSelect({
           // Focus stays where it was, so the page does not jump to the open
           // popover on load.
           autoFocusOnShow={false}
-          // Pinned to its placement for the same reason as the popover
-          // samples: the position is computed against the viewport.
+          // Pinned to its placement for the same reason as the popover samples:
+          // the position is computed against the viewport.
           flip={false}
           slide={false}
           {...props}

--- a/app/src/sandbox/ariakit-tailwind-layer-transparent/index.react.tsx
+++ b/app/src/sandbox/ariakit-tailwind-layer-transparent/index.react.tsx
@@ -20,7 +20,8 @@ export default function Example() {
           aria-hidden
           data-glider
           className="ak-layer ak-layer-15 absolute inset-y-1 -z-1 w-32 rounded-md transition-[left]"
-          // One control (w-32) plus one gap (gap-1) per step, from the p-1 inset.
+          // One control (w-32) plus one gap (gap-1) per step, from the p-1
+          // inset.
           style={{ left: `${selectedIndex * 8.25 + 0.25}rem` }}
         />
         {VIEWS.map((view, index) => (

--- a/app/src/sandbox/combobox-select-content/conditional-content.react.tsx
+++ b/app/src/sandbox/combobox-select-content/conditional-content.react.tsx
@@ -45,7 +45,10 @@ export default function ConditionalContent() {
             {""}
           </ComboboxSelectItem>
         </ComboboxSelectPopover>
-        {/* A false display value falls through to children, and an icon of 0 stays. */}
+        {/*
+         * A false display value falls through to children, and an icon of 0
+         * stays.
+         */}
         <ComboboxSelectButton
           aria-label="Status summary"
           displayValue={false}
@@ -54,7 +57,10 @@ export default function ConditionalContent() {
         >
           Summary
         </ComboboxSelectButton>
-        {/* An explicit empty string requests blank content instead of a fallback. */}
+        {/*
+         * An explicit empty string requests blank content instead of a
+         * fallback.
+         */}
         <ComboboxSelectButton
           aria-label="Blank display"
           displayValue=""

--- a/app/src/sandbox/composite-renderer-6215/index.react.tsx
+++ b/app/src/sandbox/composite-renderer-6215/index.react.tsx
@@ -92,8 +92,8 @@ export default function Example() {
             {(item) => (
               <button
                 // Bumping the key remounts the item to a new node while keeping
-                // the same id, mirroring a data refresh that recreates rows. The
-                // previous node must stop being observed.
+                // the same id, mirroring a data refresh that recreates rows.
+                // The previous node must stop being observed.
                 key={`${item.id}-${nonce}`}
                 id={item.id}
                 className="item"

--- a/app/src/sandbox/dialog-hidden-dismiss/index.react.tsx
+++ b/app/src/sandbox/dialog-hidden-dismiss/index.react.tsx
@@ -56,10 +56,10 @@ export default function Example() {
       {/*
         A nested popover is non-modal, and `portal` defaults to `modal`, so it
         renders inline inside the dialog. It also stays rendered while closed,
-        so its dismiss button sits in the dialog's subtree before the user
-        opens it. That button closes the popover, not the dialog.
+        so its dismiss button sits in the dialog's subtree before the user opens
+        it. That button closes the popover, not the dialog.
         https://github.com/ariakit/ariakit/issues/7321
-      */}
+       */}
       <Ariakit.DialogProvider>
         <Ariakit.DialogDisclosure>Compose</Ariakit.DialogDisclosure>
         <Ariakit.Dialog>
@@ -117,11 +117,11 @@ export default function Example() {
         </Ariakit.Menu>
       </Ariakit.MenuProvider>
       {/*
-        Whether the dialog needs the fallback can change while it stays open,
-        in both directions: a dialog that loads its content gains a dismiss
-        control, and one that starts a task it can't cancel loses the control
-        it had. https://github.com/ariakit/ariakit/issues/7321
-      */}
+        Whether the dialog needs the fallback can change while it stays open, in
+        both directions: a dialog that loads its content gains a dismiss
+        control, and one that starts a task it can't cancel loses the control it
+        had. https://github.com/ariakit/ariakit/issues/7321
+       */}
       <Ariakit.DialogProvider>
         <Ariakit.DialogDisclosure>Activity</Ariakit.DialogDisclosure>
         <Ariakit.Dialog>

--- a/app/src/sandbox/focus-trap-region/index.react.tsx
+++ b/app/src/sandbox/focus-trap-region/index.react.tsx
@@ -34,7 +34,8 @@ export default function Example() {
             <input
               checked={multipleEnabled}
               onChange={(event) => setMultipleEnabled(event.target.checked)}
-              // WebKit focuses the clicked checkbox only when explicitly tabbable.
+              // WebKit focuses the clicked checkbox only when explicitly
+              // tabbable.
               tabIndex={0}
               type="checkbox"
             />{" "}

--- a/app/src/sandbox/layer-color-values/index.react.tsx
+++ b/app/src/sandbox/layer-color-values/index.react.tsx
@@ -43,7 +43,9 @@ export default function Example() {
         <Text $text="brand" $textHue={120}>
           Other text hue
         </Text>
-        {/* Raw edges keep their hue visible without the contrast adjustment. */}
+        {/*
+         * Raw edges keep their hue visible without the contrast adjustment.
+         */}
         <Frame
           $edge="brand"
           $edgeRaw

--- a/app/src/sandbox/tab-4213/index.react.tsx
+++ b/app/src/sandbox/tab-4213/index.react.tsx
@@ -51,7 +51,8 @@ export default function Example() {
       <ak.TabPanel tabId="dairy">Milk, cheese, and yogurt</ak.TabPanel>
       <button
         type="button"
-        // WebKit keeps focus on the clicked button only when explicitly tabbable.
+        // WebKit keeps focus on the clicked button only when explicitly
+        // tabbable.
         tabIndex={0}
         onClick={() => setSelectedTab("vegetables")}
       >

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "open-cli": "9.0.0",
     "oxfmt": "0.67.0",
     "oxlint": "1.82.0",
-    "oxlint-plugin-comment-reflow": "0.1.2",
+    "oxlint-plugin-comment-reflow": "0.2.0",
     "oxlint-tsgolint": "7.0.2001",
     "pkg-pr-new": "0.0.88",
     "react": "19.2.8",

--- a/packages/ariakit-react-components/src/select/select.tsx
+++ b/packages/ariakit-react-components/src/select/select.tsx
@@ -217,11 +217,10 @@ export const useSelect = createHook<TagName, SelectOptions>(function useSelect({
             disabled={disabledProp}
             value={value}
             multiple={multiSelectable}
-            // Even though this element is visually hidden and is not
-            // tabbable, it's still focusable. Some autofill extensions like
-            // 1password will move focus to the next form element on autofill.
-            // In this case, we want to move focus to our custom select
-            // element.
+            // Even though this element is visually hidden and is not tabbable,
+            // it's still focusable. Some autofill extensions like 1password
+            // will move focus to the next form element on autofill. In this
+            // case, we want to move focus to our custom select element.
             onFocus={() => store?.getState().selectElement?.focus()}
             onChange={(event) => {
               nativeSelectChangedRef.current = true;

--- a/packages/ariakit-ui/src/components/list.ariakit.react.tsx
+++ b/packages/ariakit-ui/src/components/list.ariakit.react.tsx
@@ -190,8 +190,8 @@ export function ListDisclosure(props: ListDisclosureProps) {
     <Disclosure
       {...listDisclosure.jsx(variantProps)}
       {...rest}
-      // The guide has to span the whole row, open content included, so it
-      // goes on the disclosure root instead of on the button. A caller's own
+      // The guide has to span the whole row, open content included, so it goes
+      // on the disclosure root instead of on the button. A caller's own
       // decoration keeps its place alongside it.
       decoration={
         <>

--- a/packages/ariakit-ui/src/components/nav.ariakit.react.tsx
+++ b/packages/ariakit-ui/src/components/nav.ariakit.react.tsx
@@ -128,8 +128,8 @@ export function Nav({ list, glider, children, ...props }: NavProps) {
     <ak.Role.nav
       {...nav.jsx(variantProps)}
       {...rest}
-      // The inner element takes the state setter as its ref, and Ariakit
-      // merges it with the caller's ref and render element.
+      // The inner element takes the state setter as its ref, and Ariakit merges
+      // it with the caller's ref and render element.
       render={<ak.Role.nav ref={setElement} render={rest.render} />}
     >
       {renderGliders(glider)}
@@ -320,8 +320,8 @@ export function NavDisclosureContentBody(props: NavDisclosureContentBodyProps) {
   const [variantProps, rest] = splitProps(props, navDisclosureContentBody);
   return (
     <DisclosureContentBody
-      // The body paints no surface of its own: a nav glider that covers a
-      // row inside it paints under the content, and it has to show through.
+      // The body paints no surface of its own: a nav glider that covers a row
+      // inside it paints under the content, and it has to show through.
       $layer="transparent"
       {...navDisclosureContentBody.jsx(variantProps)}
       {...rest}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -266,8 +266,8 @@ importers:
         specifier: 1.82.0
         version: 1.82.0(oxlint-tsgolint@7.0.2001)
       oxlint-plugin-comment-reflow:
-        specifier: 0.1.2
-        version: 0.1.2
+        specifier: 0.2.0
+        version: 0.2.0
       oxlint-tsgolint:
         specifier: 7.0.2001
         version: 7.0.2001
@@ -8713,8 +8713,8 @@ packages:
       vite-plus:
         optional: true
 
-  oxlint-plugin-comment-reflow@0.1.2:
-    resolution: {integrity: sha512-UeQtfDSvgNomke/sArDXFYY7lDVOFhVu6emnTuQCAk5RBf7ikJQUN/d80usBCR6Tk93OdiBbtFCDnZhmIOMGRg==}
+  oxlint-plugin-comment-reflow@0.2.0:
+    resolution: {integrity: sha512-WAtekr/oIMaaUS5peTNcK6QP1bMmzvMfdICioRXD/lbWtCzRjMaVyKHe6UhgjYVNsX/sRZQfppZswoMFqzCzdg==}
     engines: {node: ^24.18.0 || >=26.0.0}
 
   oxlint-tsgolint@7.0.2001:
@@ -18742,7 +18742,7 @@ snapshots:
       '@oxfmt/binding-win32-ia32-msvc': 0.67.0
       '@oxfmt/binding-win32-x64-msvc': 0.67.0
 
-  oxlint-plugin-comment-reflow@0.1.2:
+  oxlint-plugin-comment-reflow@0.2.0:
     dependencies:
       '@oxlint/plugins': 1.82.0
 


### PR DESCRIPTION
## Motivation

Update `oxlint-plugin-comment-reflow` to apply the existing comment formatting rule inside JSX. Version 0.2.0 adds support for comments inside empty JSX expressions and standalone comments between JSX props.

## Solution

Update the root development dependency from `0.1.2` to `0.2.0`, regenerate the lockfile, and run the configured `pnpm dedupe` operation. Reflow the JSX comments reported by the new version while preserving their text and surrounding code.

The old plugin passes on the same source that produces the new JSX diagnostics with 0.2.0. These changes are valid new enforcement. For example, long `{/* comment */}` expressions now wrap inside their existing braces.

The requested version was published on September 9, 2026. It meets the dependency update workflow's explicit-target exception to the three-day Renovate release age. The pnpm release-age policy remains in force.

This update requires human review because it includes source comment changes. Automerge is disabled.

## Dependencies

| Package | Workspace / declaration | Old | New | Release |
| --- | --- | --- | --- | --- |
| `oxlint-plugin-comment-reflow` | Root `package.json`, `devDependencies` | `0.1.2` | `0.2.0` | [0.2.0 release notes](https://github.com/diegohaz/oxlint-plugin-comment-reflow/releases/tag/v0.2.0) |

## Verification

- `pnpm dedupe`
- `pnpm lint-fix`
- `pnpm lint`
- `pnpm tsc`
- Compare TypeScript output with comments removed for every modified TSX file against the base version. The emitted JavaScript is identical.
