### PR TITLE
Use the canvas layer for Ariakit UI popovers

### DIFF
--- a/packages/ariakit-ui/src/styles/combobox.ts
+++ b/packages/ariakit-ui/src/styles/combobox.ts
@@ -31,7 +31,6 @@ export const comboboxPopover = cv({
   defaultVariants: {
     $rounded: "xl",
     $p: 1,
-    $layer: "canvas",
   },
 });
 

--- a/packages/ariakit-ui/src/styles/popover.ts
+++ b/packages/ariakit-ui/src/styles/popover.ts
@@ -50,6 +50,7 @@ export const popover = cv({
     },
   },
   defaultVariants: {
+    $layer: "canvas",
     $shadow: "xl",
     $rounded: "2xl",
     $forceRounded: true,


### PR DESCRIPTION
## Motivation

An inline Ariakit UI popover on a colored surface inherits that surface's color. On a brand surface, the popover background can match its surroundings in both light and dark themes.

Closes #7479 by fixing item 3. Items 1 and 2 will not be fixed, as requested.

## Solution

Default the shared popover recipe to `$layer: "canvas"`, so its background starts from the page color. Remove the same default from `comboboxPopover`, which now inherits it. Dialog and tooltip recipes also inherit the canvas default.

Explicit layer values still override the default. For example, applications can keep a brand popover or opt into the parent color:

```tsx
<Popover $layer="brand">Brand callout</Popover>
<Popover $layer={true}>Use the parent color</Popover>
```

## Preview

The Default sandbox popover inside a brand-colored frame. Each before state uses the original recipe output; each after state uses the canvas default.

| Theme | Before | After |
| --- | --- | --- |
| Light | ![Popover matches its blue parent surface in light mode](https://github.com/user-attachments/assets/eba9c6c8-763e-401e-98c9-aa23ecbabea5) | ![Popover has a light canvas background on the blue surface](https://github.com/user-attachments/assets/41dd7ceb-4df3-45ef-a1c5-8913607c392e) |
| Dark | ![Popover matches its blue parent surface in dark mode](https://github.com/user-attachments/assets/74e645be-b41a-4839-bc62-8b23473e32d6) | ![Popover has a dark canvas background on the blue surface](https://github.com/user-attachments/assets/9bed6703-98bc-4df2-abf5-54e27b869f03) |

## Verification

- Reproduced the matching backgrounds in Chromium, then confirmed the canvas background in light and dark themes. Explicit brand colors and parent-color inheritance still work.
- Compared emitted classes and styles for default and explicit layer values. Combobox output stays the same.
- Ran the existing popover, combobox, tooltip, and dialog suites in Chromium, Firefox, and WebKit. One popover test passed on retry and passed a separate run with retries disabled. Local visual snapshot assertions remain disabled.
- `pnpm lint-fix`, `pnpm tsc`, and `pnpm build`.

No changeset is needed because `@ariakit/ui` is private and excluded from Changesets.
