### PR TITLE
Detect small changes in full-page screenshots

### DIFF
--- a/app/src/test-utils/visual.ts
+++ b/app/src/test-utils/visual.ts
@@ -425,6 +425,8 @@ export async function visual(
           });
           await expect(page).toHaveScreenshot(fileSnapshotName, {
             ...screenshotOptions,
+            // A page-sized pixel allowance can hide changes to small controls.
+            ...(fullPage && { maxDiffPixelRatio: 0 }),
             timeout,
           });
           // Touch the screenshot file so the CI stale-detection step (which


### PR DESCRIPTION
## Motivation

Small changes to controls can pass a full-page visual test because the allowed pixel difference grows with the screenshot area. This happened in #7489: the avatar and label changes passed the visual jobs, so CI did not update the screenshots.

A Chromium comparison of the deployed main and PR previews confirmed the cause. In light mode, Button changed 669 pixels against an allowance of 2,671, and Badge changed 430 against an allowance of 586. Dark mode also passed the existing `maxDiffPixelRatio: 0.0005` setting. Repeated captures of each page were identical.

## Solution

Use `maxDiffPixelRatio: 0` when `visual()` receives `fullPage: true`, including captures of an element's full height. Add the option conditionally so cropped captures keep the configured allowance. Passing `undefined` would clear that setting in Playwright.

```ts
...(fullPage && { maxDiffPixelRatio: 0 })
```

Lint and TypeScript checks pass. Five isolated Playwright checks confirm that the old setting accepts the Button and Badge changes in both color schemes, the new setting rejects them, unchanged images pass, and cropped captures keep their configured allowance. Debug captures were stored outside the repository; baseline updates run in CI.
